### PR TITLE
Shorter result return

### DIFF
--- a/commands/search.js
+++ b/commands/search.js
@@ -68,7 +68,7 @@ function Search(msg, args)  {
             }
         };
 
-        return (result[first.answerType]) ? result[first.answerType]() : result.Default();
+        return (result[first.answerType] || result.Default)();
     });
 }
 


### PR DESCRIPTION
Made the `return result[first.answerType]();` code a little bit shorter